### PR TITLE
added apple mobile web app capable meta tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,8 @@
 <meta name="apple-mobile-web-app-title" content="HackerWeb">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-status-bar-style" content="black">
 <link rel="shortcut icon" href="icons/favicon.ico">
 <link rel="shortcut icon" sizes="196x196" href="icons/favicon-196.png">
 <link rel="shortcut icon" sizes="128x128" href="icons/favicon-128.png">


### PR DESCRIPTION
used status bar style black as it is the only reliable choice for iOS +7. On iOS +7 it will appear either black or white depending on the device colour. The same colour as the startup background when booting iOS devices.
